### PR TITLE
Fix exception when sending data from WINLIBRS to LCRX NibrsXMLSubmission endpoint

### DIFF
--- a/NibrsXmlGenerator/NibrsXmlGenerator/Builder/OffenseBuilder.cs
+++ b/NibrsXmlGenerator/NibrsXmlGenerator/Builder/OffenseBuilder.cs
@@ -79,7 +79,7 @@ namespace NibrsXml.Builder
                 offenseReport.CriminalActivityCategoryCodes =
                     ExtractNibrsCriminalActivityCategoryCodes(offenses, offenseReport.UcrCode);
                 offenseReport.FactorBiasMotivationCodes = TranslateBiasMotivationCodes(uniqueBiasMotivationCodes);
-                offenseReport.StructuresEnteredQuantity = offense.First().Premises.TrimStart('0').TrimNullIfEmpty();
+                offenseReport.StructuresEnteredQuantity = offense.First().Premises.TrimStart('0')?.TrimNullIfEmpty();
                 offenseReport.Factors = TranslateOffenseFactors(uniqueSuspectedOfUsingCodes);
                 offenseReport.EntryPoint = offense.First().MethodOfEntry.TryBuild<OffenseEntryPoint>();
                 offenseReport.Forces = ExtractNibrsOffenseForces(offenses, offenseReport.UcrCode);

--- a/NibrsXmlGenerator/NibrsXmlGenerator/Builder/PersonBuilder.cs
+++ b/NibrsXmlGenerator/NibrsXmlGenerator/Builder/PersonBuilder.cs
@@ -86,9 +86,9 @@ namespace NibrsXml.Builder
                                      
                     var aggAssaults = new List<string>();
                     aggAssaults.TryAdd(
-                        victim.AggravatedAssault1.TrimNullIfEmpty(),
-                        victim.AggravatedAssault2.TrimNullIfEmpty(),
-                        victim.AggravatedAssault3.TrimNullIfEmpty());
+                        victim.AggravatedAssault1?.TrimNullIfEmpty(),
+                        victim.AggravatedAssault2?.TrimNullIfEmpty(),
+                        victim.AggravatedAssault3?.TrimNullIfEmpty());
 
                     var offenses = incident.Offense.Where(o => o.OffConnecttoVic == victim.VictimSeqNum).ToList();
                                        
@@ -105,8 +105,8 @@ namespace NibrsXml.Builder
                         newOfficer = new EnforcementOfficial(
                             person: newPerson,
                             victimSeqNum: victim.VictimSeqNum,
-                            activityCategoryCode: victim.OfficerActivityCircumstance.TrimNullIfEmpty(),
-                            assignmentCategoryCode: victim.OfficerAssignmentType.TrimNullIfEmpty(),
+                            activityCategoryCode: victim.OfficerActivityCircumstance?.TrimNullIfEmpty(),
+                            assignmentCategoryCode: victim.OfficerAssignmentType?.TrimNullIfEmpty(),
                             agencyOri: victim.OfficerOri != incident.Admin.ORINumber ? victim.OfficerOri : null);
 
                         //Add each of the new objects above to their respective lists
@@ -116,7 +116,7 @@ namespace NibrsXml.Builder
 
                             // Convert aggAssault 40 to 34 if offense is 09B else convert to 09 
                             aggravatedAssaultHomicideFactorCode: aggAssaults.Select(a => (a == "40")  ?  (is09B ? "34" : "09") : a).ToList(),
-                            justifiableHomicideFactorCode: victim.AdditionalHomicide.TrimNullIfEmpty(),
+                            justifiableHomicideFactorCode: victim.AdditionalHomicide?.TrimNullIfEmpty(),
                             uniquePrefix: uniquePrefix);
                     }
                     else
@@ -129,7 +129,7 @@ namespace NibrsXml.Builder
 
                             // Convert aggAssault 40 to 34 if offense is 09B else convert to 09 
                             aggravatedAssaultHomicideFactorCodes: aggAssaults.Select(a => (a == "40") ? (is09B ? "34" : "09") : a).ToList(),
-                            justifiableHomicideFactorCode: victim.AdditionalHomicide.TrimNullIfEmpty(),
+                            justifiableHomicideFactorCode: victim.AdditionalHomicide?.TrimNullIfEmpty(),
                             uniquePrefix: uniquePrefix);
                     }
 
@@ -321,7 +321,7 @@ namespace NibrsXml.Builder
                         //todo: ??? Does LIBRS Clearance Indicator of "O" translate to NIBRS of "N"?
                         armedWithCode:
                         incident.ArrArm.Where(armm => armm.ArrestSeqNum == librsArrestee.ArrestSeqNum)
-                            .Select(aarm => aarm.ArrestArmedWith.TrimNullIfEmpty())
+                            .Select(aarm => aarm.ArrestArmedWith?.TrimNullIfEmpty())
                             .ToList(),
                         juvenileDispositionCode: TranslateJuvenileDispositionCode(juvenileDispositionCode,librsArrestee.Age),
                         subjectCountCode: librsArrestee.MultipleArresteeIndicator,

--- a/NibrsXmlGenerator/NibrsXmlGenerator/Builder/ReportBuilder.cs
+++ b/NibrsXmlGenerator/NibrsXmlGenerator/Builder/ReportBuilder.cs
@@ -258,7 +258,7 @@ namespace NibrsXml.Builder
                     // Instantiate and add a new Substance object to the list of substances
                     nibrsSubstances.Add(new Substance(
                         drugCatCode,
-                        prop.First().EstimatedDrugQty.TrimNullIfEmpty(),
+                        prop.First().EstimatedDrugQty?.TrimNullIfEmpty(),
                         prop.First().TypeDrugMeas,
                         nibrsItemStatusCode,
                         prop.First().PropertyValue,
@@ -299,7 +299,7 @@ namespace NibrsXml.Builder
 
                     }).ToString(CultureInfo.InvariantCulture);
 
-                    var propDes = prop.First().PropertyDescription.TrimNullIfEmpty();
+                    var propDes = prop.First().PropertyDescription?.TrimNullIfEmpty();
                     var countOfProperties = NibrsCodeGroups.VehicleProperties.Contains(propDes) ? prop.Count().ToString() : null;
 
                     // Instantiate and add a new Item object to the list of items


### PR DESCRIPTION
# Changes:
- Fixed object not set to a reference exception when the aggrevatedAssault properties were null.

# Asana Tasks Involved:
- [Fix exception when sending data from WINLIBRS to LCRX NibrsXMLSubmission endpoint](https://app.asana.com/0/1207380286165003/1208254261749488/f)

# Testing:
- Verify that the example JSON file from the task processes successfully in NibrsXML\Builder\PersonBuilder.cs without throwing the exception.

# Notes:
- The `TrimNullIfWhiteSpace()` extension method only works if the string object it refers to is not null. I went ahead and made all of the places that calls that method from a string check for null first, and if so, return null.
- I had to create this task, because Kate sent this information via email, and I finished fixing this before she ever got around to making the task for it.