### PR TITLE
Fix duplicate lrs codes

### DIFF
--- a/NibrsXmlGenerator/NibrsXmlGenerator/Builder/OffenseBuilder.cs
+++ b/NibrsXmlGenerator/NibrsXmlGenerator/Builder/OffenseBuilder.cs
@@ -97,11 +97,9 @@ namespace NibrsXml.Builder
             return uniqueReportPrefix + "Offense" + offenseSeqNum.Trim().TrimStart('0');
         }
 
-        private static string ExtractNibrsCode(LIBRSOffense offense)
+        private static string ExtractNibrsCode(LIBRSOffense offense, DateTime incidentDate)
         {
-            return offense.AgencyAssignedNibrs.HasValue(true)
-                ? offense.AgencyAssignedNibrs
-                : LarsList.LarsDictionaryBuildNibrsXmlForUcrExtract[offense.LrsNumber.Trim()].Nibr;
+            return offense.AgencyAssignedNibrs;
         }
 
         private static List<string> TranslateBiasMotivationCodes(List<string> biasMotivationCodes)

--- a/NibrsXmlGenerator/NibrsXmlGenerator/Builder/OffenseBuilder.cs
+++ b/NibrsXmlGenerator/NibrsXmlGenerator/Builder/OffenseBuilder.cs
@@ -97,7 +97,7 @@ namespace NibrsXml.Builder
             return uniqueReportPrefix + "Offense" + offenseSeqNum.Trim().TrimStart('0');
         }
 
-        private static string ExtractNibrsCode(LIBRSOffense offense, DateTime incidentDate)
+        private static string ExtractNibrsCode(LIBRSOffense offense)
         {
             return offense.AgencyAssignedNibrs;
         }

--- a/NibrsXmlGenerator/NibrsXmlGenerator/Builder/PersonBuilder.cs
+++ b/NibrsXmlGenerator/NibrsXmlGenerator/Builder/PersonBuilder.cs
@@ -92,9 +92,8 @@ namespace NibrsXml.Builder
 
                     var offenses = incident.Offense.Where(o => o.OffConnecttoVic == victim.VictimSeqNum).ToList();
                                        
-                    bool is09B = offenses.Any(o => (o.AgencyAssignedNibrs.HasValue(trim: true) ? o.AgencyAssignedNibrs : LarsList.LarsDictionaryBuildNibrsXmlForUcrExtract[o.LrsNumber.Trim()].Nibr) == "09B");
-                             
-                    
+                    bool is09B = offenses.Any(o => o.AgencyAssignedNibrs.Trim() == "09B");
+
                     //Initialize officer variable to null
                     EnforcementOfficial newOfficer = null;
 

--- a/NibrsXmlGenerator/NibrsXmlGenerator/Builder/ReportBuilder.cs
+++ b/NibrsXmlGenerator/NibrsXmlGenerator/Builder/ReportBuilder.cs
@@ -321,19 +321,43 @@ namespace NibrsXml.Builder
                     incident.ArrStatute,
                     arrest => arrest.ArrestSeqNum,
                     arrlrs => arrlrs.ArrestSeqNum,
-                    (arrest, lrs) => new
+                    (arrest, lrs) =>
                     {
-                        TransactionNumber = arrest.ArrestNumber,
-                        ActivityDate = arrest.ArrestDate.ConvertToNibrsYearMonthDay(),
-                        Charge = lrs.AgencyAssignedNibrs.HasValue(true)
-                            ? lrs.AgencyAssignedNibrs
-                            : LarsList.LarsDictionaryBuildNibrsXmlForUcrExtract.TryGet(lrs.LrsNumber.Trim())?.Nibr,
-                        CategoryCode = arrest.ArrestType,
-                        ArrestCount = arrest.MultipleArresteeIndicator,
-                        SeqNum = arrest.ArrestSeqNum,
-                        //TODO: MAKE SURE TO VERIFY WHETHER THE FOLLOWING CODE SHOULD BE MODIFIED TO TAKE INTO CONSIDERATION AGENCY ASSIGNED NIBRS
-                        Rank = LarsList.LarsDictionaryBuildNibrsXmlForUcrExtract.TryGetValue(Regex.Replace(lrs.LrsNumber.Trim(), @"\s+", ""), out LibrsLars value) ? Convert.ToDouble(value.Lrank) : (Double?)null,
-                        Group = lrs.OffenseGroup,
+                        DateTime.TryParse(arrest.ArrestDate, out DateTime arrestDate);
+
+                        var expiredLars = LarsList.LarsListBuildNibrsXmlForUcrExtract
+                        .Where(x => DateTime.TryParse(x.ExpirationDate, out _) && 
+                        Regex.Replace(x.StatuteNum.Trim(), @"\s+", "") == lrs.LrsNumber)
+                        .OrderByDescending(x => x.ExpirationDate)
+                        .FirstOrDefault(x => DateTime.TryParse(x.ExpirationDate, out DateTime expDate) &&
+                        arrestDate < expDate);
+
+                        var unexpiredLars = LarsList.LarsListBuildNibrsXmlForUcrExtract
+                        .Where(x => x.ExpirationDate == null &&
+                        Regex.Replace(x.StatuteNum.Trim(), @"\s+", "") == lrs.LrsNumber).FirstOrDefault();
+
+                        Double? rank = null;
+                        if (expiredLars != null)
+                        {
+                            rank = expiredLars.Lrank.HasValue() ? Convert.ToDouble(expiredLars.Lrank) : (Double?)null;
+                        }
+                        else
+                        {
+                            rank = unexpiredLars.Lrank.HasValue() ? Convert.ToDouble(unexpiredLars.Lrank) : (Double?)null;
+                        }
+
+                        return new
+                        {
+                            TransactionNumber = arrest.ArrestNumber,
+                            ActivityDate = arrest.ArrestDate.ConvertToNibrsYearMonthDay(),
+                            Charge = lrs.AgencyAssignedNibrs,
+                            CategoryCode = arrest.ArrestType,
+                            ArrestCount = arrest.MultipleArresteeIndicator,
+                            SeqNum = arrest.ArrestSeqNum,
+                            //TODO: MAKE SURE TO VERIFY WHETHER THE FOLLOWING CODE SHOULD BE MODIFIED TO TAKE INTO CONSIDERATION AGENCY ASSIGNED NIBRS
+                            Rank = rank,
+                            Group = lrs.OffenseGroup,
+                        };
                     }
                 ).ToList();
 

--- a/NibrsXmlGenerator/NibrsXmlGenerator/Builder/ReportBuilder.cs
+++ b/NibrsXmlGenerator/NibrsXmlGenerator/Builder/ReportBuilder.cs
@@ -333,7 +333,7 @@ namespace NibrsXml.Builder
                         arrestDate < expDate);
 
                         var unexpiredLars = LarsList.LarsListBuildNibrsXmlForUcrExtract
-                        .Where(x => x.ExpirationDate == null &&
+                        .Where(x => x.ExpirationDate.IsNullBlankOrEmpty() &&
                         Regex.Replace(x.StatuteNum.Trim(), @"\s+", "") == lrs.LrsNumber).FirstOrDefault();
 
                         Double? rank = null;
@@ -343,7 +343,14 @@ namespace NibrsXml.Builder
                         }
                         else
                         {
-                            rank = unexpiredLars.Lrank.HasValue() ? Convert.ToDouble(unexpiredLars.Lrank) : (Double?)null;
+                            if (unexpiredLars != null)
+                            {
+                                rank = unexpiredLars.Lrank.HasValue() ? Convert.ToDouble(unexpiredLars.Lrank) : (Double?)null;
+                            }
+                            else
+                            {
+                                rank = null;
+                            }
                         }
 
                         return new

--- a/NibrsXmlGenerator/NibrsXmlGenerator/Builder/ReportHeaderBuilder.cs
+++ b/NibrsXmlGenerator/NibrsXmlGenerator/Builder/ReportHeaderBuilder.cs
@@ -21,11 +21,7 @@ namespace NibrsXml.Builder
         public static ReportHeader Build(List<LIBRSOffense> offenses, string actionType, LIBRSAdmin admin, string reportingPeriodYm)
         {
             //Make sure all agency assigned nibrs values are filled in regardless of the original Flat file contents/spec
-            offenses = offenses.Select(o =>
-            {
-                o.AgencyAssignedNibrs = o.AgencyAssignedNibrs.IsNullBlankOrEmpty() ? LarsList.LarsDictionaryBuildNibrsXmlForUcrExtract.TryGet(o.LrsNumber.Trim())?.Nibr : o.AgencyAssignedNibrs;
-                return o;
-            }).ToList();
+            offenses = offenses.ToList();
 
             var rptHeader = new ReportHeader();
             rptHeader.NibrsReportCategoryCode = admin.HasGroupAOffense.HasValue ? SetNibrsReportCategoryCode(admin.HasGroupAOffense) : DetermineNibrsReportCategoryCode(offenses);


### PR DESCRIPTION
# Changes:
- Fixed where the lars dictionary (now list) that I fixed in another PR was being used by replacing it with AgencyAssignedNibrs since that can no longer be null. (Kate said Raga added a validation check to throw an error if it is null.)
- Fixed Lrank when building arrest data to either get it from the current lars statute_num or if there are also expired versions, based on arrest date, get the latest expired date possible arrest date is less than.

# Testing:
- Test a flat file to make sure it processes correctly.
- Test a JSON file to make sure it processes correctly.

# Notes:
- @dougbarbin, this PR needs to be done first, because all functionality is broken in pre-alpha with the master LRS list changes causing duplicate statute numbers to exist. My next PR for tasks [Fix caps check on Json file extension check in winLIBRS batch](https://app.asana.com/0/1207380286165003/1208379326778938/f) and [Issue with Jefferson Parish File Failing since deployment](https://app.asana.com/0/1207380286165003/1208379326778922/f) will need to be done right after this because part of what I fixed in this PR is affected by the next one. This is why I hate that it's in two different submodules.